### PR TITLE
Fix NullPointerException when nextAction is null.

### DIFF
--- a/hexomato-api/src/main/java/de/siramac/hexomato/agent/mcts/MctsAgent.java
+++ b/hexomato-api/src/main/java/de/siramac/hexomato/agent/mcts/MctsAgent.java
@@ -44,11 +44,16 @@ public class MctsAgent implements Agent {
             UCTNode selectedNode = selectionResult.node();
             Integer nextAction = selectionResult.action();
 
-            // Expansion
-            UCTNode leafNode = selectedNode.expand(simulationEnv, nextAction);
-            Player winner = selectedNode.getWinner();
+            // Expansion: expand selectedNode if node is not a terminal state
+            UCTNode leafNode;
+            if (nextAction != null) {
+                leafNode = selectedNode.expand(simulationEnv, nextAction);
+            } else {
+                leafNode = selectedNode;
+            }
 
             // Simulation
+            Player winner = leafNode.getWinner();
             if (winner == null) {
                 winner = leafNode.simulate(simulationEnv);
             }

--- a/hexomato-api/src/main/java/de/siramac/hexomato/agent/mcts/UCTNode.java
+++ b/hexomato-api/src/main/java/de/siramac/hexomato/agent/mcts/UCTNode.java
@@ -102,7 +102,8 @@ public class UCTNode {
         Integer bestAction;
 
         while (true) {
-            if (currentNode.validActions.length == 0) {
+            // end select stage if all moves are played or a winning state was found
+            if (currentNode.validActions.length == 0 || currentNode.winner != null) {
                 bestAction = null;
                 break;
             }
@@ -120,22 +121,19 @@ public class UCTNode {
     }
 
     public UCTNode expand(Game simulationEnv, Integer nextAction) {
+        Node validAction = validActions[nextAction];
         simulationEnv.reset(state, activePlayer, winner);
-        UCTNode child = this;
+        simulationEnv.makeMoveOnBoard(validAction.getRow(), validAction.getCol(), activePlayer);
 
-        if (winner == null) {
-            // FIXME: nextAction can be null
-            Node validAction = validActions[nextAction];
-            simulationEnv.makeMoveOnBoard(validAction.getRow(), validAction.getCol(), activePlayer);
-            child = new UCTNode(
-                    simulationEnv.getBoard(),
-                    simulationEnv.getTurn(),
-                    simulationEnv.getValidActions(),
-                    simulationEnv.getWinner(),
-                    nextAction,
-                    this);
-            children.put(nextAction, child);
-        }
+        UCTNode child = new UCTNode(
+                simulationEnv.getBoard(),
+                simulationEnv.getTurn(),
+                simulationEnv.getValidActions(),
+                simulationEnv.getWinner(),
+                nextAction,
+                this);
+
+        children.put(nextAction, child);
         return child;
     }
 
@@ -149,7 +147,6 @@ public class UCTNode {
      * If a path was found, the winner is PLAYER_1, else PLAYER_2.
      */
     public Player simulate(Game simulationEnv) {
-        if (winner != null) return winner;
         simulationEnv.reset(state, activePlayer, null);
 
         List<Node> availableActions = new ArrayList<>(Arrays.asList(simulationEnv.getValidActions()));


### PR DESCRIPTION
Hey Dennis, 

den Bug habe ich jetzt behoben. Die Exception tritt auf, wenn bei der Baumsuche ein Endzustand erreicht wird.
Ein Endzustand im Spiel Hex ist ein Zustand, wo einer der Spieler gewonnen hat oder das Brett voll mit Steinen belegt ist.
Der zweite Fall ist recht unwahrscheinlich, da vorher mindestens einer der Spieler gewonnen hat.

Falls ein Endzustand erreicht wird, wird nun die Expansions- und Simulationsphase übersprungen und direkt die Backpropagation
von dem Endzustand ausgeführt.

Mit freundlichen Grüßen,

Hung